### PR TITLE
Fix maxAscent steamstat getting reset to a value below goatsash

### DIFF
--- a/MoreAscents/Patches/FixErrors/AchievementManager.cs
+++ b/MoreAscents/Patches/FixErrors/AchievementManager.cs
@@ -32,8 +32,8 @@ internal static class AchievementManagerPatches
                 return;
             
             Plugin.ascentsUnlocked.Value = value;
-            if (value > AscentGimmickHandler.BaseAscents-2) {
-                value = AscentGimmickHandler.BaseAscents-2;
+            if (value > AscentGimmickHandler.BaseAscents-1) {
+                value = AscentGimmickHandler.BaseAscents-1;
             }
         }
     }


### PR DESCRIPTION
Currently, as mentioned in #3, when you use the mod while having previously beaten ascent7, then unlock all ascents by holding L while opening the terminal and then uninstall the mod your steamstat variable is set to a value that indicates that you have beat ascent6, effectively re-locking the goat sash.

I suspected that the patch regarding limiting the bounds of the maxascent steamsatat was the issue, and indeed, upping the bounds by one (tested via dnSpy locally) appears to fix this issue.

Ingame your sash still appears to be silver rather than gold, but when relaunching vanilla you still have the goat sash - which is what i was primarily concerned about.

This resolves #3 