### PR TITLE
Fix chaos 4 and some other minor stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /MoreAscents/obj
 /MoreAscents/bin
+/MoreAscents/lib
 /.vs
 /.idea

--- a/MoreAscents/API/BingBongMechanics.cs
+++ b/MoreAscents/API/BingBongMechanics.cs
@@ -1,0 +1,5 @@
+﻿namespace MoreAscents.API;
+
+internal class BingBongMechanics {
+	internal static float BingBongUnheldFor = 0;
+}

--- a/MoreAscents/Ascents/Gimmicks/Chaos/BingBongGimmick.cs
+++ b/MoreAscents/Ascents/Gimmicks/Chaos/BingBongGimmick.cs
@@ -1,0 +1,54 @@
+﻿using MoreAscents.API;
+using MoreAscents.Patches;
+using UnityEngine;
+
+namespace MoreAscents;
+
+public class BingBongGimmick : AscentGimmick {
+    public override string GetDescription() {
+        return "Bing Bong calls upon an evil force if not given attention.";
+    }
+    
+    public override string GetTitle() {
+        return "Chaos 4";
+    }
+
+    private static float SinceLastShake = 0;
+    
+    public override void Update() {
+        var dt = Time.deltaTime;
+        SinceLastShake += dt;
+
+        var bingBong = BingBongPatches.heldBingBongItem;
+        bool bingBongIsHeld = bingBong != null && bingBong.itemState == ItemState.Held;
+        if (bingBongIsHeld) {
+            BingBongMechanics.BingBongUnheldFor = 0;
+        } else {
+            BingBongMechanics.BingBongUnheldFor += dt;
+        }
+
+        foreach (Character character in Character.AllCharacters) {
+            if (!character.IsLocal) {
+                continue;
+            }
+            if (character.data.passedOutOnTheBeach > 0) {
+                BingBongMechanics.BingBongUnheldFor = 0;
+                break;
+            }
+
+            // shake the screen if bingbong is about to be angry
+            if (BingBongMechanics.BingBongUnheldFor > 10 && BingBongMechanics.BingBongUnheldFor <= 15) {
+                if (SinceLastShake > 1 / 60) {
+                    SinceLastShake = 0;
+                    GamefeelHandler.instance.AddPerlinShake(0.7f, 0.15f, 15f);
+                }
+            }
+
+            // if unheld for too long, apply status effect
+            if (BingBongMechanics.BingBongUnheldFor >= 15) {
+                character.refs.afflictions.AddStatus(CharacterAfflictions.STATUSTYPE.Crab, 0.05f * Time.deltaTime, false);
+                break;
+            }
+        }
+    }
+}

--- a/MoreAscents/Ascents/Gimmicks/Chaos/SunHotGimmick.cs
+++ b/MoreAscents/Ascents/Gimmicks/Chaos/SunHotGimmick.cs
@@ -18,7 +18,8 @@ public class SunHotGimmick : AscentGimmick {
             return;
         if (DayNightManager.instance.isDay < 0.5f)
             return;
-        if (Singleton<MountainProgressHandler>.Instance.maxProgressPointReached >= 3)
+        var progressHandler = Singleton<MountainProgressHandler>.Instance;
+        if (progressHandler == null || progressHandler.maxProgressPointReached >= 3)
             return;
         
         Vector3 sunDir = -RenderSettings.sun.transform.forward;

--- a/MoreAscents/Patches/BingBongPatches.cs
+++ b/MoreAscents/Patches/BingBongPatches.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+
+namespace MoreAscents.Patches;
+
+internal class BingBongPatches
+{
+    internal static Item heldBingBongItem = null;
+    [HarmonyPatch(typeof(CharacterData), nameof(CharacterData.currentItem), MethodType.Setter)]
+    internal static class Patch {
+        [HarmonyPrefix]
+        internal static void Prefix(Item value) {
+            //if (value == null) {
+            //    Debug.LogWarning("MoreAscents::UnequippedItem");
+            //}
+            if(value != null && value.GetItemName() == "BING BONG") {
+                //Debug.LogWarning($"MoreAscents::Equipped");
+                heldBingBongItem = value;
+            } else {
+                heldBingBongItem = null; 
+            }
+        }
+    }
+}

--- a/MoreAscents/Plugin.cs
+++ b/MoreAscents/Plugin.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using BepInEx;
+﻿using BepInEx;
 using BepInEx.Logging;
-using System.Collections.Generic;
 using System.Reflection;
 using BepInEx.Configuration;
 using UnityEngine;
 using HarmonyLib;
 using MoreAscents.Patches;
-using Steamworks;
 using Zorro.Core;
 using Logger = UnityEngine.Logger;
-// test
 
 namespace MoreAscents
 {
@@ -45,6 +41,7 @@ namespace MoreAscents
             AscentGimmickHandler.RegisterAscent<SkeletonGimmick>();
             AscentGimmickHandler.RegisterAscent<CampfireGimmick>();
             AscentGimmickHandler.RegisterAscent<SunHotGimmick>();
+            AscentGimmickHandler.RegisterAscent<BingBongGimmick>();
             
             AscentGimmickHandler.Initialize();
             
@@ -72,7 +69,6 @@ namespace MoreAscents
 
         private void Update() {
             GUIManagerPatches.Grasp.SinceLastGrab += Time.deltaTime;
-
             
             foreach (AscentGimmick gimmick in AscentGimmickHandler.gimmicks) {
                 if (!gimmick.active) {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # MoreAscents
 <sub>[Now with a 30% extra chance to ruin your friendships!](https://medal.tv/games/peak/clips/kyP7Mxifu7TizEtzi?invite=cr-MSxPdEosMTkwNTA5NDMy)</sub>
 
-Adds 8 more ascents to the game for those who want to challenge themselves just a little bit more.
+Adds 9 more ascents to the game for those who want to challenge themselves just a little bit more.
 
 > [!NOTE]
 > You can now disable ascent 7 and 12 in the config for this mod located under (gamelocation)\BepInEx\config\MoreAscents.json or the config editor from r2modman/Thunderstore Mod Manager. <br> <br>

--- a/thunderstore_README.md
+++ b/thunderstore_README.md
@@ -1,7 +1,7 @@
 # MoreAscents
 <sub>[Now with a 30% extra chance to ruin your friendships!](https://medal.tv/games/peak/clips/kyP7Mxifu7TizEtzi?invite=cr-MSxPdEosMTkwNTA5NDMy)</sub>
 
-Adds 8 more ascents to the game for those who want to challenge themselves just a little bit more.
+Adds 9 more ascents to the game for those who want to challenge themselves just a little bit more.
 
 [!NOTE]
 You can now disable ascent 7 and 12 in the config for this mod located under (gamelocation)\BepInEx\config\MoreAscents.json or the config editor from r2modman/Thunderstore Mod Manager. <br>
@@ -23,4 +23,4 @@ Ascent 12 - No more Revive Statues.<br><br>
 Chaos 1 - Going unconscious is instant death.<br>
 Chaos 2 - Campfires are extremely hot.<br>
 Chaos 3 - The sun is very hot, don't get heatstroke<br>
-~~Chaos 4 - Bing Bong calls upon an evil force if not given attention.~~ not working<br>
+Chaos 4 - Bing Bong calls upon an evil force if not given attention.<br>


### PR DESCRIPTION
- reimplemented the "is bingbong held" detection - should be pretty solid now, also for future updates
- made the perlinshake thing stronger so that it is clearly visible
- moved the bingbongunheldfor incrementing directly into the bingbonggimmick class, as that is the one that sets it to 0 also
- fixed a nullreference exception for the sun-is-hot gimmick, as previously it was accessing a singleton during load which was null at that point in time
- changed the readmes to reflect that c4 works again
- updated gitignore to allow usage of /lib/ folder for dropping in dlls
