### PR TITLE
fix kiosk ascent translations

### DIFF
--- a/MoreAscents/Ascents/AscentGimmickHandler.cs
+++ b/MoreAscents/Ascents/AscentGimmickHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using MoreAscents.Patches;
 using UnityEngine;
@@ -115,5 +116,16 @@ public static class AscentGimmickHandler
         }
         pendingDatas.Add(newData);
         Plugin.Logger.LogInfo($"Queued {newData.title}");
+
+        void AddIdentityTranslation(string key, string val) {
+            if (string.IsNullOrWhiteSpace(key)) {
+                throw new NotImplementedException($"translation was empty?? {typeof(T)}");
+            }
+            LocalizedText.mainTable.Add(key.ToUpperInvariant(), Enumerable.Repeat(val.ToUpperInvariant(), LocalizedText.LANGUAGE_COUNT).ToList());
+        }
+
+        int ascentId = gimmick._ascentData.order - 2;
+        AddIdentityTranslation(gimmick.GetTitle(),gimmick.GetTitle());
+        AddIdentityTranslation($"desc_{gimmick.GetTitle()}",gimmick.GetDescription());
     }
 }


### PR DESCRIPTION
This one fixes the kiosk translations for ascent8-chaos4 (title+description)
<img width="1078" height="401" alt="image" src="https://github.com/user-attachments/assets/1f5ddee6-a6b1-4e70-80fb-59b3f9024a40" />
