### PR TITLE
fix disable-a12 setting being inverted

### DIFF
--- a/MoreAscents/Ascents/Gimmicks/OccultStatueGimmick.cs
+++ b/MoreAscents/Ascents/Gimmicks/OccultStatueGimmick.cs
@@ -14,7 +14,7 @@ public class OccultStatueGimmick : AscentGimmick
     }
 
     public override void RespawnChestExisted(Spawner chest) {
-        if (!MoreAscents.Plugin.ascent7Disabler.Value)
+        if (MoreAscents.Plugin.ascent7Disabler.Value)
             return;
         chest.gameObject.SetActive(false);
     }


### PR DESCRIPTION
If the "disable-a7+a12" setting is _false_, `if (!MoreAscents.Plugin.ascent7Disabler.Value) return;` would actually skip the patch, meaning by default, statues are spawned. This fixes this behaviour by inverting the check.

